### PR TITLE
Fix typo in web sample stylesheets

### DIFF
--- a/web-start/styles/main.css
+++ b/web-start/styles/main.css
@@ -99,7 +99,7 @@ main, #messages-card {
   color: #bbb;
   font-style: italic;
   font-size: 12px;
-  box-sixing: border-box;
+  box-sizing: border-box;
 }
 #message-form {
   display: flex;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -99,7 +99,7 @@ main, #messages-card {
   color: #bbb;
   font-style: italic;
   font-size: 12px;
-  box-sixing: border-box;
+  box-sizing: border-box;
 }
 #message-form {
   display: flex;


### PR DESCRIPTION
The web sample stylesheet has a typo which means that the author name box causes the message container to stretch horizontally.