### PR TITLE
prepping for timestamps

### DIFF
--- a/ios/swift/FriendlyChatSwift/Constants.swift
+++ b/ios/swift/FriendlyChatSwift/Constants.swift
@@ -14,8 +14,6 @@
 //  limitations under the License.
 //
 
-let currentTime = NSDate().timeIntervalSince1970
-
 struct Constants {
 
   struct NotificationKeys {

--- a/ios/swift/FriendlyChatSwift/Constants.swift
+++ b/ios/swift/FriendlyChatSwift/Constants.swift
@@ -14,6 +14,8 @@
 //  limitations under the License.
 //
 
+let currentTime = NSDate().timeIntervalSince1970
+
 struct Constants {
 
   struct NotificationKeys {

--- a/ios/swift/FriendlyChatSwift/FCViewController.swift
+++ b/ios/swift/FriendlyChatSwift/FCViewController.swift
@@ -187,6 +187,7 @@ class FCViewController: UIViewController, UITableViewDataSource, UITableViewDele
   }
 
   func sendMessage(data: [String: String]) {
+    var timeSent = ["timeSent": currentTime]
     var mdata = data
     mdata[Constants.MessageFields.name] = AppState.sharedInstance.displayName
     if let photoUrl = AppState.sharedInstance.photoUrl {
@@ -194,6 +195,7 @@ class FCViewController: UIViewController, UITableViewDataSource, UITableViewDele
     }
     // Push data to Firebase Database
     self.ref.child("messages").childByAutoId().setValue(mdata)
+    self.ref.child("messages").setValue(timeSent)
   }
 
   // MARK: - Image Picker

--- a/ios/swift/FriendlyChatSwift/FCViewController.swift
+++ b/ios/swift/FriendlyChatSwift/FCViewController.swift
@@ -34,6 +34,8 @@ class FCViewController: UIViewController, UITableViewDataSource, UITableViewDele
   // Instance variables
   @IBOutlet weak var textField: UITextField!
   @IBOutlet weak var sendButton: UIButton!
+  @IBOutlet weak var timeStampLbl: UILabel!
+ 
   var ref: FIRDatabaseReference!
   var messages: [FIRDataSnapshot]! = []
   var msglength: NSNumber = 10
@@ -187,7 +189,8 @@ class FCViewController: UIViewController, UITableViewDataSource, UITableViewDele
   }
 
   func sendMessage(data: [String: String]) {
-    var timeSent = ["timeSent": currentTime]
+    var timeStamp = NSDate().timeIntervalSince1970
+    var timeSent = ["timeSent": timeStamp]
     var mdata = data
     mdata[Constants.MessageFields.name] = AppState.sharedInstance.displayName
     if let photoUrl = AppState.sharedInstance.photoUrl {


### PR DESCRIPTION
Declaring it as a constant, and using nsdate unix epoch time. It's probably good practice to push timeSent to firebase when sendMessage function over in the viewcontroller is called. There's a lot you can do with that, and makes it much cleaner. Later you can convert epoch time to a user-friendly format and have the date and time sent displayed when user swipes over the messages (or you can just have them sit under/above the messages but that UI style is kind of cluttery.
