### PR TITLE
Fix for timestamp

### DIFF
--- a/web/storage.rules
+++ b/web/storage.rules
@@ -1,7 +1,7 @@
 service firebase.storage {
   // TODO: Change the <STORAGE_BUCKET> placeholder below. e.g. my-project-12345.appspot.com
   match /b/<STORAGE_BUCKET>/o {
-    match /{userId}/{timestamp}/{fileName} {
+    match /{userId}/{timeStamp}/{fileName} {
       allow write: if request.auth.uid == userId;
       allow read;
     }


### PR DESCRIPTION
`[E] 4:22 - timestamp is a package and cannot be used as variable name.` -> rename timestamp