### PR TITLE
Fix link to Firebase Codelab on Github

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 
 *This guide was inspired by the [AngularJS contribution guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md).*
 
-[github]: https://github.com/firebase/codelab-friendlychat
+[github]: https://github.com/firebase/friendlychat
 [google-cla]: https://cla.developers.google.com
 [js-style-guide]: http://google.github.io/styleguide/javascriptguide.xml
 [py-style-guide]: http://google.github.io/styleguide/pyguide.html


### PR DESCRIPTION
Previously link was directing to 404 page.
![image](https://cloud.githubusercontent.com/assets/1859636/19811072/996fdb12-9d38-11e6-9143-868bb5573694.png)
