### PR TITLE
Renovate Terraform examples

### DIFF
--- a/web/terraform-checkpoints/create-firebase-project-checkpoint.tf
+++ b/web/terraform-checkpoints/create-firebase-project-checkpoint.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -27,11 +27,7 @@ resource "google_project" "default" {
   # TODO: REPLACE WITH YOUR OWN VALUES
   name       = "<PROJECT_NAME_OF_YOUR_PROJECT>"
   project_id = "<PROJECT_ID_OF_YOUR_PROJECT>"
-
-  # Required for the project to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
+  billing_account = "<BILLING_ACCOUNT_ID>"
 }
 
 # Enable the required underlying Service Usage API.

--- a/web/terraform-checkpoints/register-app-checkpoint.tf
+++ b/web/terraform-checkpoints/register-app-checkpoint.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -27,11 +27,7 @@ resource "google_project" "default" {
   # TODO: REPLACE WITH YOUR OWN VALUES
   name       = "<PROJECT_NAME_OF_YOUR_PROJECT>"
   project_id = "<PROJECT_ID_OF_YOUR_PROJECT>"
-
-  # Required for the project to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
+  billing_account = "<BILLING_ACCOUNT_ID>"
 }
 
 # Enable the required underlying Service Usage API.
@@ -76,5 +72,4 @@ resource "google_firebase_web_app" "default" {
   project         = google_firebase_project.default.project
   # TODO: REPLACE WITH YOUR OWN VALUE
   display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
-  deletion_policy = "DELETE"
 }

--- a/web/terraform-checkpoints/replicate-config/main-foreach.tf
+++ b/web/terraform-checkpoints/replicate-config/main-foreach.tf
@@ -80,9 +80,9 @@ resource "google_firebase_web_app" "default" {
   provider = google-beta
   for_each = google_firebase_project.default
 
-  project         = each.value.project
+  project = each.value.project
   # TODO: REPLACE WITH YOUR OWN VALUE
-  display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
+  display_name = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
 }
 
 # UNCOMMENT BELOW IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
@@ -244,29 +244,14 @@ resource "google_project_service" "firebasestorage" {
   disable_on_destroy = false
 }
 
-# Provision a Cloud Storage bucket.
-# This is not the default Cloud Storage bucket for your project
-# (provisioning of the default bucket via Terraform is coming soon)
-resource "google_storage_bucket" "my_buckets" {
+# Provision a default Firebase Storage bucket.
+resource "google_firebase_storage_default_bucket" "bucket" {
   provider = google-beta
   for_each = google_firebase_project.default
 
   project = each.value.project
-
-  # TODO: name your bucket
-  name          = "${each.value.project}-<EXTRA_NAME_OF_BUCKET>"
-  # TODO: See available locations https://cloud.google.com/storage/docs/locations
-  location      = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
-  force_destroy = true
-}
-
-# Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "my_buckets" {
-  provider = google-beta
-  for_each = google_firebase_project.default
-
-  project   = each.value.project
-  bucket_id = google_storage_bucket.my_buckets[each.key].name
+  # See available locations: https://cloud.google.com/storage/docs/locations#available-locations
+  location = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
 
   depends_on = [
     google_project_service.firebasestorage,
@@ -291,16 +276,16 @@ resource "google_firebaserules_ruleset" "storage" {
 
   # Wait for the Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
-    google_firebase_storage_bucket.my_buckets,
+    google_firebase_storage_default_bucket.bucket,
   ]
 }
 
 # Release the ruleset to the Storage bucket.
-resource "google_firebaserules_release" "my_buckets" {
+resource "google_firebaserules_release" "bucket" {
   provider = google-beta
   for_each = google_firebase_project.default
 
-  name         = "firebase.storage/${google_firebase_storage_bucket.my_buckets[each.key].bucket_id}"
+  name         = "firebase.storage/${google_firebase_storage_default_bucket.bucket[each.key].project}.firebasestorage.app"
   ruleset_name = google_firebaserules_ruleset.storage[each.key].name
   project      = each.value.project
 }

--- a/web/terraform-checkpoints/replicate-config/main-foreach.tf
+++ b/web/terraform-checkpoints/replicate-config/main-foreach.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -29,11 +29,6 @@ resource "google_project" "default" {
   project_id = "<PROJECT_ID>-${each.key}"
   # Required if you want to set up Authentication via Terraform
   billing_account = "<YOUR_BILLING_ACCOUNT_ID>"
-
-  # Required for the projects to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
 
   # TODO: REPLACE WITH YOUR OWN VALUES
   for_each = {
@@ -88,7 +83,6 @@ resource "google_firebase_web_app" "default" {
   project         = each.value.project
   # TODO: REPLACE WITH YOUR OWN VALUE
   display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
-  deletion_policy = "DELETE"
 }
 
 # UNCOMMENT BELOW IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
@@ -224,12 +218,6 @@ resource "google_firebaserules_release" "firestore" {
   depends_on = [
     google_firestore_database.default,
   ]
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.firestore[each.key]
-    ]
-  }
 }
 
 # Enable required APIs for Cloud Storage for Firebase.
@@ -256,30 +244,29 @@ resource "google_project_service" "firebasestorage" {
   disable_on_destroy = false
 }
 
-# Provision the default Cloud Storage bucket for the project via Google App Engine.
-resource "google_app_engine_application" "default" {
+# Provision a Cloud Storage bucket.
+# This is not the default Cloud Storage bucket for your project
+# (provisioning of the default bucket via Terraform is coming soon)
+resource "google_storage_bucket" "my_buckets" {
   provider = google-beta
   for_each = google_firebase_project.default
 
   project = each.value.project
-  # See available locations: https://firebase.google.com/docs/projects/locations#default-cloud-location
-  # This will set the location for the default Storage bucket and the App Engine App.
-  # TODO: REPLACE WITH YOUR OWN VALUE
-  location_id = "<NAME_OF_DESIRED_REGION_FOR_DEFAULT_BUCKET>" # Must be in the same location as Firestore (above)
 
-  # Wait until Firestore is provisioned first.
-  depends_on = [
-    google_firestore_database.default
-  ]
+  # TODO: name your bucket
+  name          = "${each.value.project}-<EXTRA_NAME_OF_BUCKET>"
+  # TODO: See available locations https://cloud.google.com/storage/docs/locations
+  location      = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
+  force_destroy = true
 }
 
-# Make the default Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "default_bucket" {
+# Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
+resource "google_firebase_storage_bucket" "my_buckets" {
   provider = google-beta
   for_each = google_firebase_project.default
 
   project   = each.value.project
-  bucket_id = google_app_engine_application.default[each.key].default_bucket
+  bucket_id = google_storage_bucket.my_buckets[each.key].name
 
   depends_on = [
     google_project_service.firebasestorage,
@@ -302,24 +289,18 @@ resource "google_firebaserules_ruleset" "storage" {
     }
   }
 
-  # Wait for the default Storage bucket to be provisioned before creating this ruleset.
+  # Wait for the Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
-    google_firebase_storage_bucket.default_bucket,
+    google_firebase_storage_bucket.my_buckets,
   ]
 }
 
-# Release the ruleset to the default Storage bucket.
-resource "google_firebaserules_release" "default_bucket" {
+# Release the ruleset to the Storage bucket.
+resource "google_firebaserules_release" "my_buckets" {
   provider = google-beta
   for_each = google_firebase_project.default
 
-  name         = "firebase.storage/${google_app_engine_application.default[each.key].default_bucket}"
-  ruleset_name = "projects/${google_firebase_project.default[each.key].project}/rulesets/${google_firebaserules_ruleset.storage[each.key].name}"
+  name         = "firebase.storage/${google_firebase_storage_bucket.my_buckets[each.key].bucket_id}"
+  ruleset_name = google_firebaserules_ruleset.storage[each.key].name
   project      = each.value.project
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.storage
-    ]
-  }
 }

--- a/web/terraform-checkpoints/replicate-config/main_staging-copypaste.tf
+++ b/web/terraform-checkpoints/replicate-config/main_staging-copypaste.tf
@@ -187,29 +187,14 @@ resource "google_project_service" "storage_staging" {
   disable_on_destroy = false
 }
 
-# Provision a Cloud Storage bucket.
-# This is not the default Cloud Storage bucket for your project
-# (provisioning of the default bucket via Terraform is coming soon)
-resource "google_storage_bucket" "my_bucket_staging" {
+# Provision a default Firebase Storage bucket.
+resource "google_firebase_storage_default_bucket" "bucket_staging" {
   provider = google-beta
-  project  = google_firebase_project.default.project
-
-  name     = "<NAME_OF_STORAGE_BUCKET>"
+  project  = google_firebase_project.staging.project
   # See available locations: https://cloud.google.com/storage/docs/locations#available-locations
   location = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
-  force_destroy = true
-}
 
-# Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "my_bucket_staging" {
-  provider = google-beta
-
-  project   = google_firebase_project.staging.project
-  bucket_id = google_storage_bucket.my_bucket_staging.name
-
-  depends_on = [
-    google_project_service.storage_staging
-  ]
+  depends_on = [google_project_service.storage_staging]
 }
 
 # Create a ruleset of Cloud Storage Security Rules from a local file.
@@ -228,15 +213,15 @@ resource "google_firebaserules_ruleset" "storage_staging" {
 
   # Wait for the Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
-    google_firebase_storage_bucket.my_bucket_staging,
+    google_firebase_storage_default_bucket.bucket_staging,
   ]
 }
 
 # Release the ruleset to the Storage bucket.
-resource "google_firebaserules_release" "my_bucket_staging" {
+resource "google_firebaserules_release" "bucket_staging" {
   provider = google-beta
 
-  name         = "firebase.storage/${google_firebase_storage_bucket.my_bucket_staging.bucket_id}"
+  name         = "firebase.storage/${google_firebase_storage_default_bucket.bucket_staging.project}.firebasestorage.app"
   ruleset_name = google_firebaserules_ruleset.storage_staging.name
   project      = google_firebase_project.staging.project
 }

--- a/web/terraform-checkpoints/replicate-config/main_staging-copypaste.tf
+++ b/web/terraform-checkpoints/replicate-config/main_staging-copypaste.tf
@@ -3,15 +3,9 @@ resource "google_project" "staging" {
   provider = google-beta.no_user_project_override
 
   # TODO: REPLACE WITH YOUR OWN VALUES
-  name       = "<PROJECT_NAME_OF_YOUR_STAGING_PROJECT>"
-  project_id = "<PROJECT_ID_OF_YOUR_STAGING_PROJECT>"
-  # UNCOMMENT BELOW IF YOU IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
-  # billing_account = "<BILLING_ACCOUNT_ID>"
-
-  # Required for the project to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
+  name            = "<PROJECT_NAME_OF_YOUR_STAGING_PROJECT>"
+  project_id      = "<PROJECT_ID_OF_YOUR_STAGING_PROJECT>"
+  billing_account = "<BILLING_ACCOUNT_ID>"
 }
 
 # Enable the required underlying Service Usage API.
@@ -53,10 +47,9 @@ resource "google_firebase_project" "staging" {
 resource "google_firebase_web_app" "staging" {
   provider = google-beta
 
-  project         = google_firebase_project.staging.project
+  project = google_firebase_project.staging.project
   # TODO: REPLACE WITH YOUR OWN VALUE
-  display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
-  deletion_policy = "DELETE"
+  display_name = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
 }
 
 # UNCOMMENT BELOW IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
@@ -176,12 +169,6 @@ resource "google_firebaserules_release" "firestore_staging" {
   depends_on = [
     google_firestore_database.staging,
   ]
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.firestore_staging
-    ]
-  }
 }
 
 # Enable required APIs for Cloud Storage for Firebase.
@@ -200,29 +187,25 @@ resource "google_project_service" "storage_staging" {
   disable_on_destroy = false
 }
 
-# Provision the default Cloud Storage bucket for the project via Google App Engine.
-resource "google_app_engine_application" "staging" {
+# Provision a Cloud Storage bucket.
+# This is not the default Cloud Storage bucket for your project
+# (provisioning of the default bucket via Terraform is coming soon)
+resource "google_storage_bucket" "my_bucket_staging" {
   provider = google-beta
+  project  = google_firebase_project.default.project
 
-  project = google_firebase_project.staging.project
-  # See available locations: https://firebase.google.com/docs/projects/locations#default-cloud-location
-  # This will set the location for the default Storage bucket and the App Engine App.
-  # TODO: REPLACE WITH YOUR OWN VALUE
-  location_id = "<NAME_OF_DESIRED_REGION_FOR_DEFAULT_BUCKET>" # Must be in the same location as Firestore (above)
-
-  # Wait until Firestore is provisioned first.
-  depends_on = [
-    google_firestore_database.staging
-  ]
+  name     = "<NAME_OF_STORAGE_BUCKET>"
+  # See available locations: https://cloud.google.com/storage/docs/locations#available-locations
+  location = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
+  force_destroy = true
 }
 
-# Make the default Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "default_bucket_staging" {
+# Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
+resource "google_firebase_storage_bucket" "my_bucket_staging" {
   provider = google-beta
 
   project   = google_firebase_project.staging.project
-  bucket_id = google_app_engine_application.staging.default_bucket
-
+  bucket_id = google_storage_bucket.my_bucket_staging.name
 
   depends_on = [
     google_project_service.storage_staging
@@ -243,23 +226,17 @@ resource "google_firebaserules_ruleset" "storage_staging" {
     }
   }
 
-  # Wait for the default Storage bucket to be provisioned before creating this ruleset.
+  # Wait for the Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
-    google_firebase_storage_bucket.default_bucket_staging,
+    google_firebase_storage_bucket.my_bucket_staging,
   ]
 }
 
-# Release the ruleset to the default Storage bucket.
-resource "google_firebaserules_release" "default_bucket_staging" {
+# Release the ruleset to the Storage bucket.
+resource "google_firebaserules_release" "my_bucket_staging" {
   provider = google-beta
 
-  name         = "firebase.storage/${google_app_engine_application.staging.default_bucket}"
-  ruleset_name = "projects/${google_firebase_project.staging.project}/rulesets/${google_firebaserules_ruleset.storage_staging.name}"
+  name         = "firebase.storage/${google_firebase_storage_bucket.my_bucket_staging.bucket_id}"
+  ruleset_name = google_firebaserules_ruleset.storage_staging.name
   project      = google_firebase_project.staging.project
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.storage_staging
-    ]
-  }
 }

--- a/web/terraform-checkpoints/set-up-auth-checkpoint.tf
+++ b/web/terraform-checkpoints/set-up-auth-checkpoint.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -28,11 +28,6 @@ resource "google_project" "default" {
   name       = "<PROJECT_NAME_OF_YOUR_PROJECT>"
   project_id = "<PROJECT_ID_OF_YOUR_PROJECT>"
   billing_account = "<BILLING_ACCOUNT_ID>"
-
-  # Required for the project to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
 }
 
 # Enable the required underlying Service Usage API.
@@ -77,7 +72,6 @@ resource "google_firebase_web_app" "default" {
   project         = google_firebase_project.default.project
   # TODO: REPLACE WITH YOUR OWN VALUE
   display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
-  deletion_policy = "DELETE"
 }
 
 # Enable the Identity Toolkit API.

--- a/web/terraform-checkpoints/set-up-firestore-checkpoint.tf
+++ b/web/terraform-checkpoints/set-up-firestore-checkpoint.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -27,13 +27,7 @@ resource "google_project" "default" {
   # TODO: REPLACE WITH YOUR OWN VALUES
   name       = "<PROJECT_NAME_OF_YOUR_PROJECT>"
   project_id = "<PROJECT_ID_OF_YOUR_PROJECT>"
-  # UNCOMMENT BELOW IF YOU IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
-  # billing_account = "<BILLING_ACCOUNT_ID>"
-
-  # Required for the project to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
+  billing_account = "<BILLING_ACCOUNT_ID>"
 }
 
 # Enable the required underlying Service Usage API.
@@ -78,7 +72,6 @@ resource "google_firebase_web_app" "default" {
   project         = google_firebase_project.default.project
   # TODO: REPLACE WITH YOUR OWN VALUE
   display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
-  deletion_policy = "DELETE"
 }
 
 # UNCOMMENT BELOW IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
@@ -198,10 +191,4 @@ resource "google_firebaserules_release" "firestore" {
   depends_on = [
     google_firestore_database.default,
   ]
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.firestore
-    ]
-  }
 }

--- a/web/terraform-checkpoints/set-up-storage-checkpoint.tf
+++ b/web/terraform-checkpoints/set-up-storage-checkpoint.tf
@@ -2,8 +2,8 @@
 terraform {
   required_providers {
     google-beta = {
-      source = "hashicorp/google-beta"
-      version = "~> 4.0"
+      source  = "hashicorp/google-beta"
+      version = "~> 7.0"
     }
   }
 }
@@ -25,15 +25,9 @@ resource "google_project" "default" {
   provider = google-beta.no_user_project_override
 
   # TODO: REPLACE WITH YOUR OWN VALUES
-  name       = "<PROJECT_NAME_OF_YOUR_PROJECT>"
-  project_id = "<PROJECT_ID_OF_YOUR_PROJECT>"
-  # UNCOMMENT BELOW IF YOU IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
-  # billing_account = "<BILLING_ACCOUNT_ID>"
-
-  # Required for the project to display in any list of Firebase projects.
-  labels = {
-    "firebase" = "enabled"
-  }
+  name            = "<PROJECT_NAME_OF_YOUR_PROJECT>"
+  project_id      = "<PROJECT_ID_OF_YOUR_PROJECT>"
+  billing_account = "<BILLING_ACCOUNT_ID>"
 }
 
 # Enable the required underlying Service Usage API.
@@ -75,10 +69,9 @@ resource "google_firebase_project" "default" {
 resource "google_firebase_web_app" "default" {
   provider = google-beta
 
-  project         = google_firebase_project.default.project
+  project = google_firebase_project.default.project
   # TODO: REPLACE WITH YOUR OWN VALUE
-  display_name    = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
-  deletion_policy = "DELETE"
+  display_name = "<DISPLAY_NAME_OF_YOUR_WEB_APP>"
 }
 
 # UNCOMMENT BELOW IF YOU SET UP FIREBASE AUTHENTICATION USING TERRAFORM IN THE PREVIOUS STEP
@@ -198,12 +191,6 @@ resource "google_firebaserules_release" "firestore" {
   depends_on = [
     google_firestore_database.default,
   ]
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.firestore
-    ]
-  }
 }
 
 # Enable required APIs for Cloud Storage for Firebase.
@@ -222,28 +209,25 @@ resource "google_project_service" "storage" {
   disable_on_destroy = false
 }
 
-# Provision the default Cloud Storage bucket for the project via Google App Engine.
-resource "google_app_engine_application" "default" {
+# Provision a Cloud Storage bucket.
+# This is not the default Cloud Storage bucket for your project
+# (provisioning of the default bucket via Terraform is coming soon)
+resource "google_storage_bucket" "my_bucket" {
   provider = google-beta
+  project  = google_firebase_project.default.project
 
-  project = google_firebase_project.default.project
-  # See available locations: https://firebase.google.com/docs/projects/locations#default-cloud-location
-  # This will set the location for the default Storage bucket and the App Engine App.
-  # TODO: REPLACE WITH YOUR OWN VALUE
-  location_id = "<NAME_OF_DESIRED_REGION_FOR_DEFAULT_BUCKET>"  # Must be in the same location as Firestore (above)
-
-  # Wait until Firestore is provisioned first.
-  depends_on = [
-    google_firestore_database.default
-  ]
+  name     = "<NAME_OF_STORAGE_BUCKET>"
+  # See available locations: https://cloud.google.com/storage/docs/locations#available-locations
+  location = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
+  force_destroy = true
 }
 
-# Make the default Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "default_bucket" {
+# Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
+resource "google_firebase_storage_bucket" "my_bucket" {
   provider = google-beta
 
   project   = google_firebase_project.default.project
-  bucket_id = google_app_engine_application.default.default_bucket
+  bucket_id = google_storage_bucket.my_bucket.name
 
   depends_on = [
     google_project_service.storage
@@ -264,23 +248,17 @@ resource "google_firebaserules_ruleset" "storage" {
     }
   }
 
-  # Wait for the default Storage bucket to be provisioned before creating this ruleset.
+  # Wait for the Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
-    google_firebase_storage_bucket.default_bucket,
+    google_firebase_storage_bucket.my_bucket,
   ]
 }
 
-# Release the ruleset to the default Storage bucket.
-resource "google_firebaserules_release" "default_bucket" {
+# Release the ruleset to the Storage bucket.
+resource "google_firebaserules_release" "my_bucket" {
   provider = google-beta
 
-  name         = "firebase.storage/${google_app_engine_application.default.default_bucket}"
-  ruleset_name = "projects/${google_firebase_project.default.project}/rulesets/${google_firebaserules_ruleset.storage.name}"
+  name         = "firebase.storage/${google_firebase_storage_bucket.my_bucket.bucket_id}"
+  ruleset_name = google_firebaserules_ruleset.storage.name
   project      = google_firebase_project.default.project
-
-  lifecycle {
-    replace_triggered_by = [
-      google_firebaserules_ruleset.storage
-    ]
-  }
 }

--- a/web/terraform-checkpoints/set-up-storage-checkpoint.tf
+++ b/web/terraform-checkpoints/set-up-storage-checkpoint.tf
@@ -209,29 +209,14 @@ resource "google_project_service" "storage" {
   disable_on_destroy = false
 }
 
-# Provision a Cloud Storage bucket.
-# This is not the default Cloud Storage bucket for your project
-# (provisioning of the default bucket via Terraform is coming soon)
-resource "google_storage_bucket" "my_bucket" {
+# Provision a default Firebase Storage bucket.
+resource "google_firebase_storage_default_bucket" "bucket" {
   provider = google-beta
-  project  = google_firebase_project.default.project
-
-  name     = "<NAME_OF_STORAGE_BUCKET>"
+  project = google_firebase_project.default.project
   # See available locations: https://cloud.google.com/storage/docs/locations#available-locations
   location = "<NAME_OF_DESIRED_REGION_FOR_BUCKET>"
-  force_destroy = true
-}
 
-# Make the Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "my_bucket" {
-  provider = google-beta
-
-  project   = google_firebase_project.default.project
-  bucket_id = google_storage_bucket.my_bucket.name
-
-  depends_on = [
-    google_project_service.storage
-  ]
+  depends_on = [ google_project_service.storage ]
 }
 
 # Create a ruleset of Cloud Storage Security Rules from a local file.
@@ -250,15 +235,15 @@ resource "google_firebaserules_ruleset" "storage" {
 
   # Wait for the Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
-    google_firebase_storage_bucket.my_bucket,
+    google_firebase_storage_default_bucket.bucket,
   ]
 }
 
 # Release the ruleset to the Storage bucket.
-resource "google_firebaserules_release" "my_bucket" {
+resource "google_firebaserules_release" "bucket" {
   provider = google-beta
 
-  name         = "firebase.storage/${google_firebase_storage_bucket.my_bucket.bucket_id}"
+  name         = "firebase.storage/${google_firebase_storage_default_bucket.bucket.project}.firebasestorage.app"
   ruleset_name = google_firebaserules_ruleset.storage.name
   project      = google_firebase_project.default.project
 }


### PR DESCRIPTION
1. Bump provider version to 7.x
2. Billing required for now
3. Default storage buckets are no longer App Engine based. Instead, they are native
4. Other minor fixes